### PR TITLE
replace '%zu' in fastcgi build

### DIFF
--- a/src/qcgires.c
+++ b/src/qcgires.c
@@ -263,12 +263,7 @@ int qcgires_download(qentry_t *request, const char *filepath,
     printf("Content-Disposition: %s;filename=\"%s\"" CRLF, disposition, filename);
     printf("Content-Transfer-Encoding: binary" CRLF);
     printf("Accept-Ranges: bytes" CRLF);
-#ifdef ENABLE_FASTCGI
-    // libfcgi printf does not support "%ll" modifier, casting unsigned long
     printf("Content-Length: %lu" CRLF, (unsigned long)filesize);
-#else
-    printf("Content-Length: %lld" CRLF, (long long)filesize);
-#endif
     printf("Connection: close" CRLF);
     qcgires_setcontenttype(request, mime);
 

--- a/src/qentry.c
+++ b/src/qentry.c
@@ -810,16 +810,9 @@ static bool _print(qentry_t *entry, FILE *out, bool print_data)
 
     qentobj_t *obj;
     for (obj = entry->first; obj; obj = obj->next) {
-#ifdef ENABLE_FASTCGI
-        // libfcgi printf does not support "%z" modifier, casting unsigned long
         fprintf(out, "%s=%s (%lu)\n", obj->name,
                 (print_data?(char *)obj->data:"(data)"),
                 (unsigned long)obj->size);
-#else
-        fprintf(out, "%s=%s (%zu)\n", obj->name,
-                (print_data?(char *)obj->data:"(data)"),
-                (size_t)obj->size);
-#endif
     }
 
     return true;


### PR DESCRIPTION
(this is just a WIP, not asking to really merge this)

This is a fix I still need, since libfcgi somehow doesn't work with `%zu`.

Examples:

```
$ curl -i http://localhost/cgi/download.fcgi
HTTP/1.1 200 OK
Date: Tue, 13 May 2014 15:50:03 GMT
Server: Apache/2.2.22 (Debian)
Content-Disposition: inline;filename="download.c"
Accept-Ranges: bytes
Content-Length: Connection: close
Vary: Accept-Encoding
Content-Type: text/plain
```

see the `Content-Length` header, fails to terminate.
With the fix:

```
$ curl -i http://localhost/cgi/download.fcgi
HTTP/1.1 200 OK
Date: Tue, 13 May 2014 15:53:43 GMT
Server: Apache/2.2.22 (Debian)
Content-Disposition: inline;filename="download.c"
Accept-Ranges: bytes
Connection: close
Content-Length: 1901
Vary: Accept-Encoding
Content-Type: text/plain
```

and in a `cookie.fcgi` body response:

```
Total 5 entries
Name6=Value232+6 (456+55=11 (Name1=Value2 (QSESSIONID=5d2b52357965d5adf3 (_Q_CONTENTTYPE=text/plain (
```

with the fix:

```
Total 5 entries
Name6=Value232+6 (11)
456+55=11 (3)
Name1=Value2 (7)
QSESSIONID=5d2b52357965d5adf3 (19)
_Q_CONTENTTYPE=text/plain (11)
```

Maybe there is a better way to fix this code, I don't know.

```
```
