### PR TITLE
examples updated to support fcgi linked library

### DIFF
--- a/examples/cookie.c
+++ b/examples/cookie.c
@@ -24,11 +24,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************
- * $Id: cookie.c 636 2012-05-07 23:40:43Z seungyoung.kim $
  ******************************************************************************/
 
+#ifdef ENABLE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
@@ -36,6 +38,9 @@
 
 int main(void)
 {
+#ifdef ENABLE_FASTCGI
+    while(FCGI_Accept() >= 0) {
+#endif
     // Parse (GET/COOKIE/POST) queries.
     qentry_t *req = qcgireq_parse(NULL, 0);
 
@@ -76,5 +81,8 @@ int main(void)
     }
 
     req->free(req);
+#ifdef ENABLE_FASTCGI
+    }
+#endif
     return 0;
 }

--- a/examples/download.c
+++ b/examples/download.c
@@ -24,18 +24,26 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************
- * $Id: download.c 636 2012-05-07 23:40:43Z seungyoung.kim $
  ******************************************************************************/
 
+#ifdef ENABLE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include "qdecoder.h"
 
 int main(void)
 {
+#ifdef ENABLE_FASTCGI
+    while(FCGI_Accept() >= 0) {
+#endif
     qentry_t *req = qcgireq_parse(NULL, 0);
     qcgires_download(req, "download.c", "text/plain");
+#ifdef ENABLE_FASTCGI
+    }
+#endif
     return 0;
 }

--- a/examples/multivalue.c
+++ b/examples/multivalue.c
@@ -24,11 +24,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************
- * $Id: multivalue.c 636 2012-05-07 23:40:43Z seungyoung.kim $
  ******************************************************************************/
 
+#ifdef ENABLE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
@@ -36,6 +38,9 @@
 
 int main(void)
 {
+#ifdef ENABLE_FASTCGI
+    while(FCGI_Accept() >= 0) {
+#endif
     // Parse (COOKIE/GET/POST) queries.
     qentry_t *req = qcgireq_parse(NULL, 0);
     qcgires_setcontenttype(req, "text/html");
@@ -48,5 +53,8 @@ int main(void)
     }
 
     req->free(req);
+#ifdef ENABLE_FASTCGI
+    }
+#endif
     return 0;
 }

--- a/examples/query.c
+++ b/examples/query.c
@@ -24,17 +24,22 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************
- * $Id: query.c 636 2012-05-07 23:40:43Z seungyoung.kim $
  ******************************************************************************/
 
+#ifdef ENABLE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include "qdecoder.h"
 
 int main(void)
 {
+#ifdef ENABLE_FASTCGI
+    while(FCGI_Accept() >= 0) {
+#endif
     // Parse queries.
     qentry_t *req = qcgireq_parse(NULL, 0);
 
@@ -48,5 +53,8 @@ int main(void)
 
     // De-allocate memories
     req->free(req);
+#ifdef ENABLE_FASTCGI
+    }
+#endif
     return 0;
 }

--- a/examples/upload.c
+++ b/examples/upload.c
@@ -24,11 +24,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************
- * $Id: upload.c 651 2012-08-25 09:59:41Z seungyoung.kim $
  ******************************************************************************/
 
+#ifdef ENABLE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>
@@ -54,6 +56,9 @@ ssize_t savefile(const char *filepath, const void *buf, size_t size)
 
 int main(void)
 {
+#ifdef ENABLE_FASTCGI
+    while(FCGI_Accept() >= 0) {
+#endif
     // Parse queries.
     qentry_t *req = qcgireq_parse(NULL, 0);
 
@@ -91,5 +96,8 @@ int main(void)
 
     // de-allocate
     req->free(req);
+#ifdef ENABLE_FASTCGI
+    }
+#endif
     return 0;
 }

--- a/examples/uploadfile.c
+++ b/examples/uploadfile.c
@@ -24,11 +24,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************
- * $Id: uploadfile.c 636 2012-05-07 23:40:43Z seungyoung.kim $
  ******************************************************************************/
 
+#ifdef ENABLE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include "qdecoder.h"
@@ -38,6 +40,9 @@
 
 int main(void)
 {
+#ifdef ENABLE_FASTCGI
+    while(FCGI_Accept() >= 0) {
+#endif
     // parse queries
     qentry_t *req = qcgireq_setoption(NULL, true, TMPPATH, 60);
     if (req == NULL) qcgires_error(req, "Can't set option.");
@@ -83,6 +88,8 @@ int main(void)
 
     // de-allocate
     req->free(req);
-
+#ifdef ENABLE_FASTCGI
+    }
+#endif
     return 0;
 }


### PR DESCRIPTION
These are the changes I made to the examples for testing, if you are interested.
I thought about creating a different `fcgi-examples` folder, but then it made sense to use the `ENABLE_FASTCGI` switch.
This also fixed using the modules as _CGI_, when the library was in fact build with _FastCGI_.
Otherwise these won't even run as normal CGIs anymore, if my tests are correct.
