### PR TITLE
Add pkg-config (.pc) file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AC_DEFUN([Q_ARG_DISABLE], [
 AC_INIT([qDecoder], [12 RELEASE], [http://www.qdecoder.org/])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADER([config.h])
-AC_CONFIG_FILES([Makefile src/Makefile examples/Makefile])
+AC_CONFIG_FILES([Makefile src/qdecoder.pc src/Makefile examples/Makefile])
 
 ## Set path
 PATH="$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -34,6 +34,9 @@ exec_prefix	= @exec_prefix@
 ## Name
 PRGNAME		= qdecoder
 
+## pkgconfig filename
+PKGCONFIGNAME   = qdecoder.pc
+
 ## Static Library Name
 LIBNAME		= lib${PRGNAME}.a
 
@@ -45,6 +48,7 @@ SLIBREALNAME	= ${SLIBNAME}.${SLIBVERSION}
 ## System library directory
 LIBDIR		= @libdir@
 HEADERDIR	= @includedir@
+PKGCONFIGDIR    = ${LIBDIR}/pkgconfig
 
 ## Which compiler & options for release
 CC		= @CC@
@@ -82,9 +86,11 @@ qdecoder: ${OBJ}
 install: all
 	${MKDIR} -p ${HEADERDIR}
 	${MKDIR} -p ${LIBDIR}
+	${MKDIR} -p ${PKGCONFIGDIR}
 	${INSTALL_DATA} qdecoder.h ${HEADERDIR}/qdecoder.h
 	${INSTALL_DATA} ${LIBNAME} ${LIBDIR}/${LIBNAME}
 	${INSTALL_DATA} ${SLIBREALNAME} ${LIBDIR}/${SLIBREALNAME}
+	${INSTALL_DATA} ${PKGCONFIGNAME} ${PKGCONFIGDIR}/${PKGCONFIGNAME}
 	( cd ${LIBDIR}; ${LN_S} -f ${SLIBREALNAME} ${SLIBNAME} )
 
 deinstall: uninstall
@@ -93,7 +99,9 @@ uninstall:
 	${RM} -f ${LIBDIR}/${LIBNAME}
 	${RM} -f ${LIBDIR}/${SLIBREALNAME}
 	${RM} -f ${LIBDIR}/${SLIBNAME}
+	${RM} -f ${PKGCONFIGDIR}/${PKGCONFIGNAME}
 	${RMDIR} -p --ignore-fail-on-non-empty ${HEADERDIR}
+	${RMDIR} -p --ignore-fail-on-non-empty ${PKGCONFIGDIR}
 	${RMDIR} -p --ignore-fail-on-non-empty ${LIBDIR}
 
 doc:

--- a/src/qdecoder.pc.in
+++ b/src/qdecoder.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: qDecoder
+Description: CGI library for C/C++
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lqdecoder
+Cflags: -I${includedir}


### PR DESCRIPTION
This makes it easy to integrate qDecoder with users
of autotools projects.

Projects that uses autotools just need to put into their
configure.ac file:

  PKG_CHECK_MODULES([QDECODER], [qdecoder])

And into their Makefile.am:

  a_out_CFLAGS  = $(QDECODER_CFLAGS)
  a_out_cgi_LDFLAGS = $(QDECODER_LIBS)