### PR TITLE
configure.ac: drop hardcoded paths when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,11 @@ AC_CONFIG_FILES([Makefile src/qdecoder.pc src/Makefile examples/Makefile])
 
 ## Set path
 PATH="$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
-CPPFLAGS="$CPPFLAGS -I/usr/include -I/usr/local/include -I./ -D_GNU_SOURCE"
-LDFLAGS="$LDFLAGS -L/usr/lib -L/usr/local/lib"
+CPPFLAGS="$CPPFLAGS -I./ -D_GNU_SOURCE"
+if test "x$cross_compiling" != "xyes"; then
+	CPPFLAGS="$CPPFLAGS -I/usr/include -I/usr/local/include"
+	LDFLAGS="$LDFLAGS -L/usr/lib -L/usr/local/lib"
+fi
 
 ## Set autoconf setting
 #AC_CANONICAL_TARGET


### PR DESCRIPTION
Causing problems with cross compilation.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/qdecoder/0002-configure.ac-drop-hardcoded-paths.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>